### PR TITLE
Feature/home shinhan api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,11 @@
         "jsonwebtoken": "^9.0.2",
         "morgan": "~1.9.1",
         "mysql2": "^3.10.0",
+        "node-cron": "^3.0.3",
         "reflect-metadata": "^0.2.2",
         "sequelize": "^6.37.3",
-        "sequelize-typescript": "^2.1.6"
+        "sequelize-typescript": "^2.1.6",
+        "winston": "^3.13.0"
       },
       "devDependencies": {
         "@types/bcryptjs": "^2.4.6",
@@ -32,11 +34,20 @@
         "@types/jsonwebtoken": "^9.0.6",
         "@types/morgan": "^1.9.9",
         "@types/node": "^20.14.2",
+        "@types/node-cron": "^3.0.11",
         "@types/sequelize": "^4.28.20",
         "@types/validator": "^13.11.10",
         "nodemon": "^3.1.0",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.4.5"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -49,6 +60,16 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "dependencies": {
+        "colorspace": "1.1.x",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -239,6 +260,12 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@types/node-cron": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/node-cron/-/node-cron-3.0.11.tgz",
+      "integrity": "sha512-0ikrnug3/IyneSHqCBeslAhlK2aBfYek1fGo4bP4QnZPmiqSGRK+Oy7ZMisLWkesffJvQ1cqAcBnJC+8+nxIAg==",
+      "dev": true
+    },
     "node_modules/@types/qs": {
       "version": "6.9.15",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.15.tgz",
@@ -295,6 +322,11 @@
       "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
     },
     "node_modules/@types/validator": {
       "version": "13.11.10",
@@ -357,6 +389,11 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
+    },
+    "node_modules/async": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -488,6 +525,46 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/color": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
+      "dependencies": {
+        "color-convert": "^1.9.3",
+        "color-string": "^1.6.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/colorspace": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+      "dependencies": {
+        "color": "^3.1.3",
+        "text-hex": "1.0.x"
       }
     },
     "node_modules/combined-stream": {
@@ -657,6 +734,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -726,6 +808,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -754,6 +841,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -955,6 +1047,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1014,6 +1111,17 @@
       "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -1059,6 +1167,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+    },
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1098,6 +1211,27 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+    },
+    "node_modules/logform": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+      "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/logform/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/long": {
       "version": "5.2.3",
@@ -1293,6 +1427,17 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nodemon": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.3.tgz",
@@ -1386,6 +1531,14 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/parseurl": {
@@ -1485,6 +1638,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -1541,6 +1707,14 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+      "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1732,6 +1906,14 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -1771,6 +1953,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -1778,6 +1968,33 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/strip-bom": {
       "version": "3.0.0",
@@ -1821,6 +2038,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -1854,6 +2076,14 @@
       "dev": true,
       "bin": {
         "tree-kill": "cli.js"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-node": {
@@ -1989,6 +2219,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -2025,6 +2260,40 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
+      "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.7.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+      "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+      "dependencies": {
+        "logform": "^2.3.2",
+        "readable-stream": "^3.6.0",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/wkx": {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "jsonwebtoken": "^9.0.2",
     "morgan": "~1.9.1",
     "mysql2": "^3.10.0",
+    "node-cron": "^3.0.3",
     "reflect-metadata": "^0.2.2",
     "sequelize": "^6.37.3",
-    "sequelize-typescript": "^2.1.6"
+    "sequelize-typescript": "^2.1.6",
+    "winston": "^3.13.0"
   },
   "devDependencies": {
     "@types/bcryptjs": "^2.4.6",
@@ -33,6 +35,7 @@
     "@types/jsonwebtoken": "^9.0.6",
     "@types/morgan": "^1.9.9",
     "@types/node": "^20.14.2",
+    "@types/node-cron": "^3.0.11",
     "@types/sequelize": "^4.28.20",
     "@types/validator": "^13.11.10",
     "nodemon": "^3.1.0",

--- a/src/controllers/ColumnBoardController.ts
+++ b/src/controllers/ColumnBoardController.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from "express";
+import { ColumnBoard } from "../models/columnBoard";
+
+export const getColumnBoardData = async (req: Request, res: Response) => {
+  try {
+    const columnBoardData = await ColumnBoard.findAll();
+    res.json(columnBoardData);
+  } catch (error) {
+    res.status(500).json({ error: "Failed to fetch data" });
+  }
+};

--- a/src/controllers/shinhanApiController.ts
+++ b/src/controllers/shinhanApiController.ts
@@ -1,6 +1,21 @@
 import { Request, Response } from "express";
 import axios from "axios";
 import https from "https";
+import { Op } from "sequelize";
+import { ColumnBoard } from "../models/columnBoard";
+import { sequelize } from "../models";
+import logger from "../logger";
+
+export interface MarketIssue {
+  bbsName: string;
+  title: string;
+  regDate: string;
+  messageId: string;
+  attachmentUrl: string;
+  content: string;
+  viewCount: string;
+  writer: string;
+}
 
 const instance = axios.create({
   httpsAgent: new https.Agent({
@@ -14,11 +29,9 @@ if (!apiKeyValue) {
   throw new Error("API_KEY_VALUE is not defined in the environment variables.");
 }
 
-export const getMarketIssues = async (
-  req: Request,
-  res: Response
-): Promise<void> => {
+export const fetchAndStoreMarketIssues = async (): Promise<void> => {
   try {
+    logger.info("Fetching market issues from Shinhan API");
     const shinhanResponse = await instance.get(
       "https://gapi.shinhansec.com:8443/openapi/v1.0/strategy/market-issue",
       {
@@ -30,9 +43,70 @@ export const getMarketIssues = async (
         },
       }
     );
-    res.json(shinhanResponse.data);
-  } catch (error) {
-    console.error("Error fetching data from Shinhan API", error);
-    res.status(500).json({ error: "Error fetching data from Shinhan API" });
+
+    const issues: MarketIssue[] = shinhanResponse.data.dataBody.list;
+
+    // DB에서 기존 데이터를 조회
+    const existingIssues = await ColumnBoard.findAll({
+      attributes: ["bbs_name", "title", "reg_date"],
+      where: {
+        title: {
+          [Op.in]: issues.map((issue) => issue.title),
+        },
+        reg_date: {
+          [Op.in]: issues.map((issue) => new Date(issue.regDate)),
+        },
+      },
+    });
+
+    // 중복 여부 확인
+    const newIssues = issues.filter((issue) => {
+      return !existingIssues.some(
+        (existingIssue) =>
+          existingIssue.title === issue.title &&
+          existingIssue.reg_date.getTime() === new Date(issue.regDate).getTime()
+      );
+    });
+
+    // 중복되지 않은 데이터 삽입
+    for (const issue of newIssues) {
+      await ColumnBoard.create({
+        bbs_name: issue.bbsName,
+        title: issue.title,
+        writer: issue.writer,
+        reg_date: new Date(issue.regDate),
+        attachment_url: issue.attachmentUrl,
+        content: issue.content,
+      });
+      logger.info(
+        `Stored new issue: ${issue.title} ${issue.writer} ${issue.regDate}`
+      );
+    }
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      logger.error("Error fetching data from Shinhan API: " + error.message);
+    } else {
+      logger.error("Unknown error occurred");
+    }
+  }
+};
+
+// Express route handler for testing
+export const getMarketIssues = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    logger.info("Manual trigger to fetch market issues");
+    await fetchAndStoreMarketIssues();
+    res.json({ message: "Data fetched and stored successfully" });
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      logger.error("Error fetching data from Shinhan API: " + error.message);
+      res.status(500).json({ error: "Error fetching data from Shinhan API" });
+    } else {
+      logger.error("Unknown error occurred");
+      res.status(500).json({ error: "Unknown error occurred" });
+    }
   }
 };

--- a/src/controllers/shinhanApiController.ts
+++ b/src/controllers/shinhanApiController.ts
@@ -7,7 +7,7 @@ import { sequelize } from "../models";
 import logger from "../logger";
 import moment from "moment-timezone";
 
-export interface MarketIssue {
+export interface ColumnList {
   bbsName: string;
   title: string;
   regDate: string;
@@ -30,33 +30,79 @@ if (!apiKeyValue) {
   throw new Error("API_KEY_VALUE is not defined in the environment variables.");
 }
 
+const fetchMarketIssues = async (): Promise<ColumnList[]> => {
+  const response = await instance.get(
+    "https://gapi.shinhansec.com:8443/openapi/v1.0/strategy/market-issue",
+    {
+      headers: {
+        apiKey: apiKeyValue,
+        "Access-Control-Allow-Origin": "*",
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36",
+      },
+    }
+  );
+  return response.data.dataBody.list.map((item: any) => ({
+    bbsName: item.bbsName,
+    title: item.title,
+    regDate: item.regDate,
+    messageId: item.messageId,
+    attachmentUrl: item.attachmentUrl,
+    content: item.content,
+    viewCount: item.viewCount,
+    writer: item.writer,
+  }));
+};
+
+const fetchInvestStrategies = async (): Promise<ColumnList[]> => {
+  const response = await instance.get(
+    "https://gapi.shinhansec.com:8443/openapi/v1.0/strategy/invest",
+    {
+      headers: {
+        apiKey: apiKeyValue,
+        "Access-Control-Allow-Origin": "*",
+        "User-Agent":
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36",
+      },
+    }
+  );
+  return response.data.dataBody.list.map((item: any) => ({
+    bbsName: item.bbs_name,
+    title: item.title,
+    regDate: item.reg_date,
+    messageId: item.message_id,
+    attachmentUrl: item.attachment_url,
+    content: item.content,
+    viewCount: item.view_count,
+    writer: item.writer,
+  }));
+};
+
 export const fetchAndStoreMarketIssues = async (): Promise<void> => {
   try {
     logger.info("Fetching market issues from Shinhan API");
-    const shinhanResponse = await instance.get(
-      "https://gapi.shinhansec.com:8443/openapi/v1.0/strategy/market-issue",
-      {
-        headers: {
-          apiKey: apiKeyValue,
-          "Access-Control-Allow-Origin": "*",
-          "User-Agent":
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.110 Safari/537.36",
-        },
-      }
-    );
+    const marketIssues = await fetchMarketIssues();
+    logger.info(
+      `Fetched ${marketIssues.length} market issues from Shinhan API`
+    ); // API 호출 후 받아온 데이터 개수 로그
 
-    const issues: MarketIssue[] = shinhanResponse.data.dataBody.list;
-    logger.info(`Fetched ${issues.length} market issues from Shinhan API`); // API 호출 후 받아온 데이터 개수 로그
+    logger.info("Fetching investment strategies from Shinhan API");
+    const investStrategies = await fetchInvestStrategies();
+    logger.info(
+      `Fetched ${investStrategies.length} investment strategies from Shinhan API`
+    ); // API 호출 후 받아온 데이터 개수 로그
+
+    const allIssues = [...marketIssues, ...investStrategies];
 
     // DB에서 기존 데이터를 조회
     const existingIssues = await ColumnBoard.findAll({
       attributes: ["bbs_name", "title", "reg_date"],
       where: {
         title: {
-          [Op.in]: issues.map((issue) => issue.title),
+          [Op.in]: allIssues.map((issue) => issue.title),
         },
         reg_date: {
-          [Op.in]: issues.map((issue) => issue.regDate),
+          [Op.in]: allIssues.map((issue) => issue.regDate),
         },
       },
     });
@@ -66,13 +112,11 @@ export const fetchAndStoreMarketIssues = async (): Promise<void> => {
     ); // 기존 데이터베이스에서 조회된 데이터 개수 로그
 
     // 중복 여부 확인
-    const newIssues = issues.filter((issue) => {
+    const newIssues = allIssues.filter((issue) => {
       return !existingIssues.some((existingIssue) => {
         const existingDate = moment(existingIssue.reg_date).format(
           "YYYY.MM.DD"
         ); // 날짜 문자열 변환
-        // logger.info(`Comparing ${existingIssue.title} with ${issue.title}`); // 제목 비교 로그
-        // logger.info(`Comparing ${existingDate} with ${issue.regDate}`); // 날짜 비교 로그
         return (
           existingIssue.title === issue.title && existingDate === issue.regDate
         );
@@ -94,8 +138,8 @@ export const fetchAndStoreMarketIssues = async (): Promise<void> => {
         content: issue.content,
       });
       logger.info(
-        `Stored new issue: ${issue.title} ${issue.writer} ${issue.regDate}` // 삽입된 데이터 로그
-      );
+        `Stored new issue: ${issue.title} ${issue.writer} ${issue.regDate}`
+      ); // 삽입된 데이터 로그
     }
   } catch (error: unknown) {
     if (error instanceof Error) {
@@ -112,7 +156,7 @@ export const getMarketIssues = async (
   res: Response
 ): Promise<void> => {
   try {
-    logger.info("Manual trigger to fetch market issues"); // 수동 트리거 로그
+    logger.info("Manual trigger to fetch market issues");
     await fetchAndStoreMarketIssues();
     res.json({ message: "Data fetched and stored successfully" });
   } catch (error: unknown) {

--- a/src/controllers/shinhanApiController.ts
+++ b/src/controllers/shinhanApiController.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import https from "https";
 import { Op } from "sequelize";
 import { ColumnBoard } from "../models/columnBoard";
-import { sequelize } from "../models";
+
 import logger from "../logger";
 import moment from "moment-timezone";
 
@@ -102,7 +102,9 @@ export const fetchAndStoreMarketIssues = async (): Promise<void> => {
           [Op.in]: allIssues.map((issue) => issue.title),
         },
         reg_date: {
-          [Op.in]: allIssues.map((issue) => issue.regDate),
+          [Op.in]: allIssues.map((issue) =>
+            moment(issue.regDate, "YYYY.MM.DD").toDate()
+          ), // 날짜 형식 변환
         },
       },
     });
@@ -133,7 +135,7 @@ export const fetchAndStoreMarketIssues = async (): Promise<void> => {
         bbs_name: issue.bbsName,
         title: issue.title,
         writer: issue.writer,
-        reg_date: issue.regDate,
+        reg_date: moment(issue.regDate, "YYYY.MM.DD").toDate(), // 날짜 형식 변환
         attachment_url: issue.attachmentUrl,
         content: issue.content,
       });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,18 @@
+import { createLogger, format, transports } from "winston";
+
+const { combine, timestamp, printf } = format;
+
+const customFormat = printf(({ level, message, timestamp }) => {
+  return `${timestamp} [${level}]: ${message}`;
+});
+
+const logger = createLogger({
+  level: "info",
+  format: combine(timestamp(), customFormat),
+  transports: [
+    new transports.Console(),
+    new transports.File({ filename: "combined.log" }),
+  ],
+});
+
+export default logger;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,8 @@
 import { createLogger, format, transports } from "winston";
+import moment from "moment-timezone";
+import path from "path";
 
-const { combine, timestamp, printf } = format;
+const { combine, printf } = format;
 
 const customFormat = printf(({ level, message, timestamp }) => {
   return `${timestamp} [${level}]: ${message}`;
@@ -8,10 +10,17 @@ const customFormat = printf(({ level, message, timestamp }) => {
 
 const logger = createLogger({
   level: "info",
-  format: combine(timestamp(), customFormat),
+  format: combine(
+    format.timestamp({
+      format: () => moment().tz("Asia/Seoul").format("YYYY-MM-DD HH:mm:ss"),
+    }),
+    customFormat
+  ),
   transports: [
     new transports.Console(),
-    new transports.File({ filename: "combined.log" }),
+    new transports.File({
+      filename: path.join(__dirname, "logs", "combined.log"),
+    }),
   ],
 });
 

--- a/src/models/columnBoard.ts
+++ b/src/models/columnBoard.ts
@@ -1,0 +1,50 @@
+import { Table, Column, Model, DataType } from "sequelize-typescript";
+
+@Table({
+  tableName: "Column_Board",
+  timestamps: true, // createdAt, updatedAt을 자동으로 관리합니다.
+})
+export class ColumnBoard extends Model {
+  @Column({
+    type: DataType.INTEGER.UNSIGNED,
+    autoIncrement: true,
+    primaryKey: true,
+  })
+  id!: number;
+
+  @Column({
+    type: DataType.STRING(255),
+    allowNull: false,
+  })
+  bbs_name!: string;
+
+  @Column({
+    type: DataType.STRING(255),
+    allowNull: false,
+  })
+  title!: string;
+
+  @Column({
+    type: DataType.STRING(255),
+    allowNull: false,
+  })
+  writer!: string;
+
+  @Column({
+    type: DataType.DATEONLY,
+    allowNull: false,
+  })
+  reg_date!: Date;
+
+  @Column({
+    type: DataType.TEXT,
+    allowNull: true,
+  })
+  attachment_url?: string;
+
+  @Column({
+    type: DataType.TEXT,
+    allowNull: true,
+  })
+  content?: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -10,6 +10,7 @@ import { ChallengePostComment } from "./challengePostComment";
 import { Reward } from "./reward";
 import { UserReward } from "./userReward";
 import { UserCurrentLearning } from "./userCurrentLearning";
+import { ColumnBoard } from "./columnBoard";
 
 import sequelize from "../config/db";
 import { Sequelize } from "sequelize-typescript";
@@ -41,6 +42,7 @@ sequelize.addModels([
   Reward,
   UserReward,
   UserCurrentLearning,
+  ColumnBoard,
 ]);
 
 export const initializeDatabase = async () => {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -56,3 +56,5 @@ export const initializeDatabase = async () => {
     throw error; // 에러를 던져서 서버 시작을 중단시킬 수 있음
   }
 };
+
+export { sequelize }; // 추가

--- a/src/routes/columnBoard.ts
+++ b/src/routes/columnBoard.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { getColumnBoardData } from "../controllers/ColumnBoardController";
+
+const router = Router();
+
+router.get("/list", getColumnBoardData);
+
+export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -2,6 +2,7 @@ import { Application, Router } from "express";
 import users from "./users";
 import challenge from "./challenge";
 import shinhan from "./shinhanApi";
+import columnboard from "./columnBoard";
 
 // const apiRouter = (app: Application): void => {
 //   app.use("/users", users);
@@ -12,5 +13,6 @@ const apiRouter = Router();
 apiRouter.use("/users", users);
 apiRouter.use("/challenge", challenge);
 apiRouter.use("/shinhan", shinhan);
+apiRouter.use("/columnboard", columnboard);
 
 export default apiRouter;

--- a/src/schedulers/marketIssueScheduler.ts
+++ b/src/schedulers/marketIssueScheduler.ts
@@ -1,0 +1,22 @@
+import cron from "node-cron";
+import { fetchAndStoreMarketIssues } from "../controllers/shinhanApiController";
+import logger from "../logger";
+
+// 매시간마다 실행되는 스케줄러 설정
+cron.schedule("0 * * * *", async () => {
+  logger.info("[Scheduler] triggered");
+  try {
+    await fetchAndStoreMarketIssues();
+    console.log("[Scheduler] Fetching and storing market issues...");
+    logger.info("[Scheduler] Market issues fetched and stored successfully");
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      console.log("[Scheduler] Market issues fetched and stored.");
+      logger.error(
+        "[Scheduler] Error fetching and storing market issues: " + error.message
+      );
+    } else {
+      logger.error("Unknown error occurred");
+    }
+  }
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import logger from "morgan";
 import cors from "cors";
 import dotenv from "dotenv";
 import { initializeDatabase } from "./models";
+import "./schedulers/marketIssueScheduler";
 
 import apiRouter from "./routes";
 


### PR DESCRIPTION
# 변경사항
- [신한투자증권 마켓이슈 OpenAPI 데이터 저장을 위한 테이블 생성](https://github.com/PDA-JUTOPIA/JUTOPIA-SERVER/commit/fc5d5d28e74646bb9970a0dd8c2b46f3f09b9166)
- [신한투자증권 마켓이슈 OpenAPI의 응답을 DB 데이터와 비교 후 새로 받은 데이터만 DB에 INSERT하도록 구현](https://github.com/PDA-JUTOPIA/JUTOPIA-SERVER/commit/98f0bdc3bdc61510a070002fd4da959f93e93ee0)
- [1시간마다 신한투자증권 마켓이슈 OpenAPI 데이터를 가져와 중복 없는 데이터를 DB에 저장하는 스케줄링 기능 추가](https://github.com/PDA-JUTOPIA/JUTOPIA-SERVER/commit/a5e9535a7b742752fe1169c996fa649c54467dfa)
- [신한투자증권 투자전략 OpenAPI에 대해 데이터 수집하고 DB에 저장하는 스케줄링 기능 구현](https://github.com/PDA-JUTOPIA/JUTOPIA-SERVER/commit/bcb2770b65e5cebd1fda6949bf443f631c33b9c9)
- [ColumnBoard 조회 API 개발 완료](https://github.com/PDA-JUTOPIA/JUTOPIA-SERVER/commit/4168f32e1001d4aa5d28d3fbd70710a580d696e9)
