### PR TITLE
인증 포스팅 post id 조회 api 구현 및 이미지 주소 등록되는 컬럼 길이 변경

### DIFF
--- a/src/controllers/ChallengeParticipation.ts
+++ b/src/controllers/ChallengeParticipation.ts
@@ -117,3 +117,19 @@ export async function getUserIdByParticipationId(req: Request, res: Response) {
       .json({ error: "Failed to fetch user ID by participation ID" });
   }
 }
+
+// challenge_id를 통해 참여중인 challenge_participation_id를 조회 => 배열로 리턴
+export async function getParticipationIdByChallengeId(
+  challenge_id: number
+): Promise<number[]> {
+  const participations = await ChallengeParticipation.findAll({
+    where: {
+      challenge_id: challenge_id,
+    },
+    attributes: ["challenge_participation_id"],
+  });
+
+  return participations.map(
+    (participation) => participation.challenge_participation_id
+  );
+}

--- a/src/controllers/ChallengePostController.ts
+++ b/src/controllers/ChallengePostController.ts
@@ -4,6 +4,7 @@ import { PostPhoto } from "../models/postPhoto";
 import { ChallengeParticipation } from "../models/challengeParticipation";
 import { sequelize } from "../models";
 import { getUserIdByEmail } from "./UserController"; // 사용자 이메일을 통해 user_id를 찾는 함수 import
+import { getParticipationIdByChallengeId } from "./ChallengeParticipation";
 
 export const setChallengePostDirectory = (
   req: Request,
@@ -262,6 +263,55 @@ export async function getPostIdsByEmailAndChallenge(
     const posts = await ChallengePost.findAll({
       where: {
         challenge_participation_id: challengeParticipationId,
+      },
+      attributes: ["challenge_post_id"],
+      order: [["createdAt", "DESC"]],
+    });
+
+    const postIds = posts.map((post) => post.challenge_post_id);
+
+    res.status(200).json({
+      message: "Post IDs retrieved successfully",
+      postIds: postIds,
+    });
+  } catch (error) {
+    if (error instanceof Error) {
+      console.log("Error:", error.message);
+      res.status(500).json({
+        error: "Failed to retrieve post IDs",
+        details: error.message,
+      });
+    } else {
+      console.log("Error:", error);
+      res.status(500).json({
+        error: "Failed to retrieve post IDs",
+        details: String(error),
+      });
+    }
+  }
+}
+
+// 챌린지에 있는 전체 포스트 ID 조회하는 API 엔드포인트
+export async function getPostIdsByChallengeId(req: Request, res: Response) {
+  try {
+    const { challenge_id } = req.params;
+    console.log("Challenge ID:", challenge_id);
+
+    // challengeId를 통해 모든 challengeParticipationId 조회
+    const challengeParticipationIds = await getParticipationIdByChallengeId(
+      Number(challenge_id)
+    );
+
+    if (challengeParticipationIds.length === 0) {
+      return res.status(404).json({
+        message: "No challenge participation found for this challenge ID",
+      });
+    }
+
+    // ChallengePost 테이블에서 challengeParticipationId 배열에 해당하는 모든 행 조회 (createdAt 순으로 내림차순 정렬)
+    const posts = await ChallengePost.findAll({
+      where: {
+        challenge_participation_id: challengeParticipationIds,
       },
       attributes: ["challenge_post_id"],
       order: [["createdAt", "DESC"]],

--- a/src/models/challenge.ts
+++ b/src/models/challenge.ts
@@ -25,7 +25,7 @@ export class Challenge extends Model {
   challenge_detail!: string;
 
   @Column({
-    type: DataType.STRING,
+    type: DataType.STRING(1024),
     allowNull: false,
   })
   challenge_thumbnail!: string;

--- a/src/models/postPhoto.ts
+++ b/src/models/postPhoto.ts
@@ -27,7 +27,7 @@ export class PostPhoto extends Model {
   challenge_post_id!: number;
 
   @Column({
-    type: DataType.STRING,
+    type: DataType.STRING(1024),
     allowNull: false,
   })
   post_photo_url!: string;

--- a/src/routes/challengePost.ts
+++ b/src/routes/challengePost.ts
@@ -4,6 +4,7 @@ import {
   setChallengePostDirectory,
   deleteChallengePost,
   getPostIdsByEmailAndChallenge,
+  getPostIdsByChallengeId,
 } from "../controllers/ChallengePostController";
 import { imageUploader } from "../middleware/image.uploader";
 
@@ -41,5 +42,7 @@ router.get(
   "/get-user-post/:challenge_id/:email",
   getPostIdsByEmailAndChallenge
 );
+
+router.get("/get-all-post/:challenge_id", getPostIdsByChallengeId);
 
 export default router;

--- a/src/routes/challengePost.ts
+++ b/src/routes/challengePost.ts
@@ -3,6 +3,7 @@ import {
   createChallengePost,
   setChallengePostDirectory,
   deleteChallengePost,
+  getPostIdsByEmailAndChallenge,
 } from "../controllers/ChallengePostController";
 import { imageUploader } from "../middleware/image.uploader";
 
@@ -35,5 +36,10 @@ router.post(
 );
 
 router.delete("/del-post/:postId/:email", deleteChallengePost);
+
+router.get(
+  "/get-user-post/:challenge_id/:email",
+  getPostIdsByEmailAndChallenge
+);
 
 export default router;


### PR DESCRIPTION
# 변경사항
- [유저의 email과 challenge ID로 개인이 특정 챌린지에 작성한 인증 포스팅을 조회한 뒤 Post ID를 내림차순으로 정렬된 배열로 반환하는 api 구현](https://github.com/PDA-JUTOPIA/JUTOPIA-SERVER/commit/8d818287b2729998a86a511880655410f0dc5d31) 
- [챌린지에 생성된 전체 인증 포스팅 post id를 내림차순 정렬된 배열로 받아오는 api 구현](https://github.com/PDA-JUTOPIA/JUTOPIA-SERVER/commit/aeea0ed2b80a60c505a38b266284c06de3f6be05)
- [이미지 주소 등록되는 컬럼 길이 변경](https://github.com/PDA-JUTOPIA/JUTOPIA-SERVER/pull/34/commits/fc302e96124c486a43590135785dcbcaaa52a946)